### PR TITLE
fix: Identifier 'visitedNodes' already declared issue

### DIFF
--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -86,17 +86,18 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
   }
 
   function callSyncRef(): void {
-    gen.code(_`const visitedNodes = visitedNodesForRef.get(${v}) || new Set();`)
-    gen.if(_`!visitedNodes.has(${cxt.data})`, () => {
-      gen.code(_`visitedNodesForRef.set(${v}, visitedNodes);`)
-      gen.code(_`const dataNode = ${cxt.data};`)
-      gen.code(_`visitedNodes.add(dataNode);`)
+    const visitedNodes: Name = gen.name("visitedNodes")
+    gen.code(_`const ${visitedNodes} = visitedNodesForRef.get(${v}) || new Set()`)
+    gen.if(_`!${visitedNodes}.has(${cxt.data})`, () => {
+      gen.code(_`visitedNodesForRef.set(${v}, ${visitedNodes})`)
+      gen.code(_`const dataNode = ${cxt.data}`)
+      gen.code(_`${visitedNodes}.add(dataNode)`)
       const res = cxt.result(
         callValidateCode(cxt, v, passCxt),
         () => addEvaluatedFrom(v),
         () => addErrorsFrom(v),
       )
-      gen.code(_`visitedNodes.delete(dataNode);`)
+      gen.code(_`${visitedNodes}.delete(dataNode)git`)
       return res;
     });
   }

--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -97,7 +97,7 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
         () => addEvaluatedFrom(v),
         () => addErrorsFrom(v),
       )
-      gen.code(_`${visitedNodes}.delete(dataNode)git`)
+      gen.code(_`${visitedNodes}.delete(dataNode)`)
       return res;
     });
   }


### PR DESCRIPTION
fix: Identifier 'visitedNodes' has already been declared.
