### PR TITLE
fix: support mapping in discriminator

### DIFF
--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -9,7 +9,7 @@ export function parseJson(s: string, pos: number): unknown {
     parseJson.position = pos + s.length
     return JSON.parse(s)
   } catch (e) {
-    matches = rxParseJson.exec(e.message)
+    matches = rxParseJson.exec((e as Error).message)
     if (!matches) {
       parseJson.message = "unexpected end"
       return undefined

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -61,7 +61,7 @@ const def: CodeKeywordDefinition = {
     }
 
     function findDiscriminatorTagName(schema: AnySchemaObject, tagName: string): AnySchemaObject | undefined {
-      const sch = isRef(schema) ? loadSchemaSync?.(it.baseId, schema['$ref'], '') : schema;
+      const sch = isRef(schema) ? loadSchemaSync?.(it.baseId, schema['$ref'], schema.id || schema.$id || '') : schema;
       if (!sch) {
         throw new Error(`Cannot resolve reference ${schema['$ref']}`);
       }

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -66,7 +66,7 @@ const def: CodeKeywordDefinition = {
     }
 
     function isRef(schema: object) {
-      return Object.keys(schema).includes("$ref")
+      return schema.hasOwnProperty("$ref")
     }
 
     function findDiscriminatorTagName(

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -26,10 +26,8 @@ const def: CodeKeywordDefinition = {
       schema,
       parentSchema,
       it,
-      it: {
-        opts: {loadSchemaSync},
-      },
     } = cxt
+    const { loadSchemaSync } = it.opts;
     const {oneOf} = parentSchema
     if (!it.opts.discriminator) {
       throw new Error("discriminator: requires discriminator option")

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -61,7 +61,11 @@ const def: CodeKeywordDefinition = {
     }
 
     function findDiscriminatorTagName(schema: AnySchemaObject, tagName: string): AnySchemaObject | undefined {
-      const schemaObject = isRef(schema) ? loadSchemaSync?(it.baseId, schema['$ref']) : schema;
+      const sch = isRef(schema) ? loadSchemaSync?.(it.baseId, schema['$ref'], '') : schema;
+      if (!sch) {
+        throw new Error(`Cannot resolve reference ${schema['$ref']}`);
+      }
+      const schemaObject = sch as AnySchemaObject;
       if (schemaObject.properties && schemaObject.properties[tagName]) {
         return { id: schemaObject['$id'], schema: schemaObject.properties[tagName], required: schemaObject.required };
       }

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -20,14 +20,8 @@ const def: CodeKeywordDefinition = {
   schemaType: "object",
   error,
   code(cxt: KeywordCxt) {
-    const {
-      gen,
-      data,
-      schema,
-      parentSchema,
-      it,
-    } = cxt
-    const { loadSchemaSync } = it.opts;
+    const {gen, data, schema, parentSchema, it} = cxt
+    const {loadSchemaSync} = it.opts
     const {oneOf} = parentSchema
     if (!it.opts.discriminator) {
       throw new Error("discriminator: requires discriminator option")
@@ -80,9 +74,8 @@ const def: CodeKeywordDefinition = {
       const schemaObject = sch as AnySchemaObject
       if (schemaObject.properties && schemaObject.properties[tagName]) {
         return {
-          id: schemaObject["$id"],
-          schema: schemaObject.properties[tagName],
-          required: schemaObject.required,
+          schema: schemaObject,
+          propSchema: schemaObject.properties[tagName],
         }
       }
 
@@ -113,13 +106,13 @@ const def: CodeKeywordDefinition = {
       const topRequired = hasRequired(parentSchema)
       let tagRequired = true
       for (let i = 0; i < oneOf.length; i++) {
-        const sch = oneOf[i]
-        const propSch = findDiscriminatorTagName(sch, tagName)
-        if (typeof propSch != "object") {
+        const findDiscriminatorTagResult = findDiscriminatorTagName(oneOf[i], tagName)
+        if (typeof findDiscriminatorTagResult != "object") {
           throw new Error(`discriminator: oneOf schemas must have "properties/${tagName}"`)
         }
-        tagRequired = tagRequired && (topRequired || hasRequired(propSch))
-        propSch.id && addMappings(propSch.schema, propSch.id || i)
+        const {schema, propSchema} = findDiscriminatorTagResult
+        tagRequired = tagRequired && (topRequired || hasRequired(schema))
+        schema["$id"] && addMappings(propSchema, schema["$id"] || i)
       }
       if (!tagRequired) throw new Error(`discriminator: "${tagName}" must be required`)
       return transformOneOfMapping(oneOfMapping)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Fixes [#235](https://github.com/Redocly/openapi-cli/issues/235)

**What changes did you make?**

Implemented support for mapping in discriminator

**Note**
`no-invalid-media-type-examples` should be configured with `disallowAdditionalProperties` set to false:
```yaml
lint:
  rules:
    no-invalid-media-type-examples:
      severity: warn
      disallowAdditionalProperties: false
```
as stated [here](https://github.com/Redocly/openapi-cli/issues/230#issuecomment-735149765)


**Is there anything that requires more attention while reviewing?**

**Testing**

Tested with following examples

<details>
   <summary>Schema with references</summary>

```json
{
  "openapi": "3.0.2",
  "info": {
    "title": "API",
    "version": "1.0"
  },
  "servers": [
    {
      "url": "//petstore.swagger.io/v2",
      "description": "Default server"
    }
  ],
  "components": {
    "schemas": {
      "Pet": {
        "type": "object",
        "properties": {
          "petType": {
            "type": "string",
            "enum": [
              "Dog",
              "Cat"
            ]
          }
        }
      },
      "Dog": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "packSize": {
                "type": "integer"
              }
            }
          }
        ]
      },
      "Cat": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "huntingSkill": {
                "type": "string"
              }
            }
          }
        ]
      },
      "House": {
        "type": "object",
        "properties": {
          "address": {
            "type": "string"
          },
          "pet": {
            "type": "object",
            "oneOf": [
              {
                "$ref": "#/components/schemas/Dog"
              },
              {
                "$ref": "#/components/schemas/Cat"
              }
            ],
            "discriminator": {
              "propertyName": "petType",
              "mapping": {
                "dog": "#/components/schemas/Dog",
                "cat": "#/components/schemas/Cat"
              }
            }
          }
        }
      }
    }
  },
  "paths": {
    "/house": {
      "post": {
        "operationId": "newHouse",
        "summary": "New house",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/House"
              },
              "examples": {
                "HouseWithDog": {
                  "value": {
                    "pet": {
                      "petType": "dog",
                      "packSize": 1
                    },
                    "address": "abc"
                  }
                },
                "HouseWithCat": {
                  "value": {
                    "pet": {
                      "petType": "cat",
                      "huntingSkill": "adventurous"
                    },
                    "address": "abc"
                  }
                }
              }
            }
          }
        },
        "responses": {

        }
      }
    }
  }
}

```
</details>

<details>
  <summary>Dereferenced schema</summary>

  ```json
   {
  "openapi": "3.0.2",
  "info": {
    "title": "API",
    "version": "1.0"
  },
  "servers": [
    {
      "url": "//petstore.swagger.io/v2",
      "description": "Default server"
    }
  ],
  "components": {
    "schemas": {
      "Pet": {
        "type": "object",
        "properties": {
          "petType": {
            "type": "string",
            "enum": [
              "Dog",
              "Cat"
            ]
          }
        }
      },
      "Dog": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "packSize": {
                "type": "integer"
              }
            }
          }
        ]
      },
      "Cat": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "huntingSkill": {
                "type": "string"
              }
            }
          }
        ]
      },
      "House": {
        "type": "object",
        "properties": {
          "address": {
            "type": "string"
          },
          "pet": {
            "type": "object",
            "oneOf": [
              {
                "type": "object",
                "properties": {
                  "petType": {
                    "type": "string",
                    "enum": [
                      "dog"
                    ]
                  },
                  "packSize": {
                    "type": "integer"
                  }
                },
                "required": [
                  "petType"
                ]
              },
              {
                "type": "object",
                "properties": {
                  "petType": {
                    "type": "string",
                    "enum": [
                      "cat"
                    ]
                  },
                  "huntingSkill": {
                    "type": "string"
                  }
                },
                "required": [
                  "petType"
                ]
              }
            ],
            "discriminator": {
              "propertyName": "petType",
              "mapping": {
                "dog": "#/components/schemas/Dog",
                "cat": "#/components/schemas/Cat"
              }
            }
          }
        }
      }
    }
  },
  "paths": {
    "/house": {
      "post": {
        "operationId": "newHouse",
        "summary": "New house",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/House"
              },
              "examples": {
                "HouseWithDog": {
                  "value": {
                    "pet": {
                      "petType": "dog",
                      "packSize": 1
                    },
                    "address": "abc"
                  }
                },
                "HouseWithCat": {
                  "value": {
                    "pet": {
                      "petType": "cat",
                      "huntingSkill": "adventurous"
                    },
                    "address": "abc"
                  }
                }
              }
            }
          }
        },
        "responses": {

        }
      }
    }
  }
}
  ```
</details>