### PR TITLE
feature: support mapping for discriminator

### DIFF
--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -9,7 +9,7 @@ export function parseJson(s: string, pos: number): unknown {
     parseJson.position = pos + s.length
     return JSON.parse(s)
   } catch (e) {
-    matches = rxParseJson.exec(e.message)
+    matches = rxParseJson.exec((e as Error).message)
     if (!matches) {
       parseJson.message = "unexpected end"
       return undefined

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -27,7 +27,6 @@ const def: CodeKeywordDefinition = {
     }
     const tagName = schema.propertyName
     if (typeof tagName != "string") throw new Error("discriminator: requires propertyName")
-    if (schema.mapping) throw new Error("discriminator: mapping is not supported")
     if (!oneOf) throw new Error("discriminator: requires oneOf keyword")
     const valid = gen.let("valid", false)
     const tag = gen.const("tag", _`${data}${getProperty(tagName)}`)
@@ -57,13 +56,30 @@ const def: CodeKeywordDefinition = {
       return _valid
     }
 
+    function isRef(schema: AnySchemaObject) {
+      return schema.hasOwnProperty('$ref');
+    }
+
     function getMapping(): {[T in string]?: number} {
       const oneOfMapping: {[T in string]?: number} = {}
       const topRequired = hasRequired(parentSchema)
       let tagRequired = true
       for (let i = 0; i < oneOf.length; i++) {
         const sch = oneOf[i]
-        const propSch = sch.properties?.[tagName]
+        let propSch;
+        if (isRef(sch)) {
+          // compare the ref pointer to the one in mapping
+          const { mapping } = schema
+          Object.keys(mapping).forEach(function(key) {
+            if (mapping[key] === sch['$ref']) {
+              addMapping(key, i);
+            }
+          })
+          continue;
+        } else {
+          // find if raw schema contains tagName
+          propSch = sch.properties?.[tagName]
+        }
         if (typeof propSch != "object") {
           throw new Error(`discriminator: oneOf schemas must have "properties/${tagName}"`)
         }

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -69,12 +69,21 @@ const def: CodeKeywordDefinition = {
         let propSch;
         if (isRef(sch)) {
           // compare the ref pointer to the one in mapping
-          const { mapping } = schema
-          Object.keys(mapping).forEach(function(key) {
-            if (mapping[key] === sch['$ref']) {
-              addMapping(key, i);
+          if (schema.mapping) {
+            const { mapping } = schema
+            let matchedKey;
+            Object.keys(mapping).forEach(function(key) {
+              if (mapping[key] === sch['$ref']) {
+                matchedKey = key;
+              }
+            })
+
+            if (matchedKey) {
+              addMapping(matchedKey, i);
+            } else {
+              throw new Error(`${sch['$ref']} should have corresponding entry in mapping`)
             }
-          })
+          }
           continue;
         } else {
           // find if raw schema contains tagName


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Fixes [#235](https://github.com/Redocly/openapi-cli/issues/235)

**What changes did you make?**

Implemented support for mapping in discriminator

**Note**
`no-invalid-media-type-examples` should be configured with `disallowAdditionalProperties` set to false:
```yaml
lint:
  rules:
    no-invalid-media-type-examples:
      severity: warn
      disallowAdditionalProperties: false
```
as stated [here](https://github.com/Redocly/openapi-cli/issues/230#issuecomment-735149765)


**Is there anything that requires more attention while reviewing?**

**Testing**

Tested with following examples

<details>
   <summary>Schema with references</summary>

```json
{
  "openapi": "3.0.2",
  "info": {
    "title": "API",
    "version": "1.0"
  },
  "servers": [
    {
      "url": "//petstore.swagger.io/v2",
      "description": "Default server"
    }
  ],
  "components": {
    "schemas": {
      "Pet": {
        "type": "object",
        "properties": {
          "petType": {
            "type": "string",
            "enum": [
              "Dog",
              "Cat"
            ]
          }
        }
      },
      "Dog": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "packSize": {
                "type": "integer"
              }
            }
          }
        ]
      },
      "Cat": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "huntingSkill": {
                "type": "string"
              }
            }
          }
        ]
      },
      "House": {
        "type": "object",
        "properties": {
          "address": {
            "type": "string"
          },
          "pet": {
            "type": "object",
            "oneOf": [
              {
                "$ref": "#/components/schemas/Dog"
              },
              {
                "$ref": "#/components/schemas/Cat"
              }
            ],
            "discriminator": {
              "propertyName": "petType",
              "mapping": {
                "dog": "#/components/schemas/Dog",
                "cat": "#/components/schemas/Cat"
              }
            }
          }
        }
      }
    }
  },
  "paths": {
    "/house": {
      "post": {
        "operationId": "newHouse",
        "summary": "New house",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/House"
              },
              "examples": {
                "HouseWithDog": {
                  "value": {
                    "pet": {
                      "petType": "dog",
                      "packSize": 1
                    },
                    "address": "abc"
                  }
                },
                "HouseWithCat": {
                  "value": {
                    "pet": {
                      "petType": "cat",
                      "huntingSkill": "adventurous"
                    },
                    "address": "abc"
                  }
                }
              }
            }
          }
        },
        "responses": {

        }
      }
    }
  }
}

```
</details>

<details>
  <summary>Dereferenced schema</summary>

  ```json
   {
  "openapi": "3.0.2",
  "info": {
    "title": "API",
    "version": "1.0"
  },
  "servers": [
    {
      "url": "//petstore.swagger.io/v2",
      "description": "Default server"
    }
  ],
  "components": {
    "schemas": {
      "Pet": {
        "type": "object",
        "properties": {
          "petType": {
            "type": "string",
            "enum": [
              "Dog",
              "Cat"
            ]
          }
        }
      },
      "Dog": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "packSize": {
                "type": "integer"
              }
            }
          }
        ]
      },
      "Cat": {
        "type": "object",
        "allOf": [
          {
            "$ref": "#/components/schemas/Pet"
          },
          {
            "type": "object",
            "properties": {
              "huntingSkill": {
                "type": "string"
              }
            }
          }
        ]
      },
      "House": {
        "type": "object",
        "properties": {
          "address": {
            "type": "string"
          },
          "pet": {
            "type": "object",
            "oneOf": [
              {
                "type": "object",
                "properties": {
                  "petType": {
                    "type": "string",
                    "enum": [
                      "dog"
                    ]
                  },
                  "packSize": {
                    "type": "integer"
                  }
                },
                "required": [
                  "petType"
                ]
              },
              {
                "type": "object",
                "properties": {
                  "petType": {
                    "type": "string",
                    "enum": [
                      "cat"
                    ]
                  },
                  "huntingSkill": {
                    "type": "string"
                  }
                },
                "required": [
                  "petType"
                ]
              }
            ],
            "discriminator": {
              "propertyName": "petType",
              "mapping": {
                "dog": "#/components/schemas/Dog",
                "cat": "#/components/schemas/Cat"
              }
            }
          }
        }
      }
    }
  },
  "paths": {
    "/house": {
      "post": {
        "operationId": "newHouse",
        "summary": "New house",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/House"
              },
              "examples": {
                "HouseWithDog": {
                  "value": {
                    "pet": {
                      "petType": "dog",
                      "packSize": 1
                    },
                    "address": "abc"
                  }
                },
                "HouseWithCat": {
                  "value": {
                    "pet": {
                      "petType": "cat",
                      "huntingSkill": "adventurous"
                    },
                    "address": "abc"
                  }
                }
              }
            }
          }
        },
        "responses": {

        }
      }
    }
  }
}
  ```
</details>
