### PR TITLE
Fix/unevaluated properties by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ docs/license.md
 docs/.vuepress/components/Contributors/
 docs/packages/*
 !docs/packages/README.md
+
+.idea/

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -116,6 +116,7 @@ export function compileSchema(this: Ajv, sch: SchemaEnv): SchemaEnv {
   const {es5, lines} = this.opts.code
   const {ownProperties} = this.opts
   const gen = new CodeGen(this.scope, {es5, lines, ownProperties})
+
   let _ValidationError
   if (sch.$async) {
     _ValidationError = gen.scopeValue("Error", {
@@ -164,7 +165,7 @@ export function compileSchema(this: Ajv, sch: SchemaEnv): SchemaEnv {
     gen.optimize(this.opts.code.optimize)
     // gen.optimize(1)
     const validateCode = gen.toString()
-    sourceCode = `${gen.scopeRefs(N.scope)}return ${validateCode}`
+    sourceCode = `const visitedNodesForRef = new WeakMap(); ${gen.scopeRefs(N.scope)}return ${validateCode}`;
     // console.log((codeSize += sourceCode.length), (nodeCount += gen.nodeCount))
     if (this.opts.code.process) sourceCode = this.opts.code.process(sourceCode, sch)
     // console.log("\n\n\n *** \n", sourceCode)

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -206,9 +206,9 @@ export function resolveRef(
   this: Ajv,
   root: SchemaEnv,
   baseId: string,
-  ref: string
+  origRef: string
 ): AnySchema | SchemaEnv | undefined {
-  ref = resolveUrl(baseId, ref)
+  const ref = resolveUrl(baseId, origRef)
   const schOrFunc = root.refs[ref]
   if (schOrFunc) return schOrFunc
 
@@ -217,6 +217,15 @@ export function resolveRef(
     const schema = root.localRefs?.[ref] // TODO maybe localRefs should hold SchemaEnv
     const {schemaId} = this.opts
     if (schema) _sch = new SchemaEnv({schema, schemaId, root, baseId})
+  }
+
+  if (_sch === undefined && this.opts.loadSchemaSync) {
+    const remoteSchema = this.opts.loadSchemaSync(baseId, origRef, ref)
+
+    if (remoteSchema && !(this.refs[ref] || this.schemas[ref])) {
+      this.addSchema(remoteSchema, ref, undefined)
+      _sch = resolve.call(this, root, ref)
+    }
   }
 
   if (_sch === undefined) return

--- a/lib/compile/validate/index.ts
+++ b/lib/compile/validate/index.ts
@@ -264,21 +264,25 @@ function iterateKeywords(it: SchemaObjCxt, group: RuleGroup): void {
   } = it
   if (useDefaults) assignDefaults(it, group.type)
   gen.block(() => {
-    
     for (const rule of group.rules) {
       
       if (shouldUseRule(schema, rule)) {
-  
+        
+
         keywordCode(it, rule.keyword, rule.definition, group.type)
       }
-      if(rule.keyword === 'properties' ){
 
+      if(rule.keyword === 'properties' ){
         if(it.opts.defaultAdditionalProperties === false && !/allOf\/[0-9]+$/g.test(it.errSchemaPath)) {
-          keywordCode(it, "unevaluatedProperties", apDef, group.type)
-        }
+        
+         keywordCode(it, "unevaluatedProperties", apDef, group.type)
+    
       }
     }
-    if (it.opts.defaultAdditionalProperties === false && schema?.properties === undefined && schema?.allOf !== undefined) {
+  }
+    
+    if (it.opts.defaultAdditionalProperties === false && schema?.properties === undefined && schema?.allOf !== undefined) { 
+      
       keywordCode(it, "unevaluatedProperties", apDef, group.type)
     }
   })

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -112,6 +112,8 @@ export interface CurrentOptions {
   loadSchemaSync?: (base: string, $ref: string, id: string) => AnySchemaObject | boolean
   // options to modify validated data:
   removeAdditional?: boolean | "all" | "failing"
+  defaultAdditionalProperties?: boolean;
+
   useDefaults?: boolean | "empty"
   coerceTypes?: boolean | "array"
   // advanced options:

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -109,6 +109,7 @@ export interface CurrentOptions {
   schemas?: AnySchema[] | {[Key in string]?: AnySchema}
   logger?: Logger | false
   loadSchema?: (uri: string) => Promise<AnySchemaObject>
+  loadSchemaSync?: (base: string, $ref: string, id: string) => AnySchemaObject | boolean
   // options to modify validated data:
   removeAdditional?: boolean | "all" | "failing"
   useDefaults?: boolean | "empty"

--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -9,7 +9,7 @@ export function parseJson(s: string, pos: number): unknown {
     parseJson.position = pos + s.length
     return JSON.parse(s)
   } catch (e) {
-    matches = rxParseJson.exec(e.message)
+    matches = rxParseJson.exec((e as Error).message)
     if (!matches) {
       parseJson.message = "unexpected end"
       return undefined

--- a/lib/vocabularies/applicator/additionalProperties.ts
+++ b/lib/vocabularies/applicator/additionalProperties.ts
@@ -30,7 +30,8 @@ const def: CodeKeywordDefinition & AddedKeywordDefinition = {
   trackErrors: true,
   error,
   code(cxt) {
-    const {gen, schema, parentSchema, data, errsCount, it} = cxt
+    const {gen, parentSchema, data, errsCount, it} = cxt
+    const { schema = it.opts.defaultAdditionalProperties } = cxt
     /* istanbul ignore if */
     if (!errsCount) throw new Error("ajv implementation error")
     const {allErrors, opts} = it

--- a/lib/vocabularies/applicator/properties.ts
+++ b/lib/vocabularies/applicator/properties.ts
@@ -10,7 +10,7 @@ const def: CodeKeywordDefinition = {
   schemaType: "object",
   code(cxt: KeywordCxt) {
     const {gen, schema, parentSchema, data, it} = cxt
-    if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined) {
+    if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined || it.opts.defaultAdditionalProperties === false) {
       apDef.code(new KeywordCxt(it, apDef, "additionalProperties"))
     }
     const allProps = allSchemaProperties(schema)

--- a/lib/vocabularies/applicator/properties.ts
+++ b/lib/vocabularies/applicator/properties.ts
@@ -10,7 +10,7 @@ const def: CodeKeywordDefinition = {
   schemaType: "object",
   code(cxt: KeywordCxt) {
     const {gen, schema, parentSchema, data, it} = cxt
-    if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined || it.opts.defaultAdditionalProperties === false) {
+    if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined) {
       apDef.code(new KeywordCxt(it, apDef, "additionalProperties"))
     }
     const allProps = allSchemaProperties(schema)

--- a/lib/vocabularies/applicator/properties.ts
+++ b/lib/vocabularies/applicator/properties.ts
@@ -9,6 +9,8 @@ const def: CodeKeywordDefinition = {
   type: "object",
   schemaType: "object",
   code(cxt: KeywordCxt) {
+   
+
     const {gen, schema, parentSchema, data, it} = cxt
     if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined) {
       apDef.code(new KeywordCxt(it, apDef, "additionalProperties"))
@@ -17,7 +19,9 @@ const def: CodeKeywordDefinition = {
     for (const prop of allProps) {
       it.definedProperties.add(prop)
     }
+  
     if (it.opts.unevaluated && allProps.length && it.props !== true) {
+      
       it.props = mergeEvaluated.props(gen, toHash(allProps), it.props)
     }
     const properties = allProps.filter((p) => !alwaysValidSchema(it, schema[p]))

--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -86,11 +86,19 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
   }
 
   function callSyncRef(): void {
-    cxt.result(
-      callValidateCode(cxt, v, passCxt),
-      () => addEvaluatedFrom(v),
-      () => addErrorsFrom(v)
-    )
+    gen.code(_`const visitedNodes = visitedNodesForRef.get(${v}) || new Set();`)
+    gen.if(_`!visitedNodes.has(${cxt.data})`, () => {
+      gen.code(_`visitedNodesForRef.set(${v}, visitedNodes);`)
+      gen.code(_`const dataNode = ${cxt.data};`)
+      gen.code(_`visitedNodes.add(dataNode);`)
+      const res = cxt.result(
+        callValidateCode(cxt, v, passCxt),
+        () => addEvaluatedFrom(v),
+        () => addErrorsFrom(v),
+      )
+      gen.code(_`visitedNodes.delete(dataNode);`)
+      return res;
+    });
   }
 
   function addErrorsFrom(source: Code): void {

--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -7,6 +7,7 @@ import N from "../../compile/names"
 import {SchemaEnv, resolveRef} from "../../compile"
 import {mergeEvaluated} from "../../compile/util"
 
+
 const def: CodeKeywordDefinition = {
   keyword: "$ref",
   schemaType: "string",

--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -86,17 +86,18 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
   }
 
   function callSyncRef(): void {
-    gen.code(_`const visitedNodes = visitedNodesForRef.get(${v}) || new Set();`)
-    gen.if(_`!visitedNodes.has(${cxt.data})`, () => {
-      gen.code(_`visitedNodesForRef.set(${v}, visitedNodes);`)
-      gen.code(_`const dataNode = ${cxt.data};`)
-      gen.code(_`visitedNodes.add(dataNode);`)
+    const visitedNodes: Name = gen.name("visitedNodes")
+    gen.code(_`const ${visitedNodes} = visitedNodesForRef.get(${v}) || new Set()`)
+    gen.if(_`!${visitedNodes}.has(${cxt.data})`, () => {
+      gen.code(_`visitedNodesForRef.set(${v}, ${visitedNodes})`)
+      gen.code(_`const dataNode = ${cxt.data}`)
+      gen.code(_`${visitedNodes}.add(dataNode)`)
       const res = cxt.result(
         callValidateCode(cxt, v, passCxt),
         () => addEvaluatedFrom(v),
         () => addErrorsFrom(v),
       )
-      gen.code(_`visitedNodes.delete(dataNode);`)
+      gen.code(_`${visitedNodes}.delete(dataNode)`)
       return res;
     });
   }

--- a/lib/vocabularies/unevaluated/unevaluatedProperties.ts
+++ b/lib/vocabularies/unevaluated/unevaluatedProperties.ts
@@ -3,6 +3,7 @@ import type {
   KeywordErrorDefinition,
   ErrorObject,
   AnySchema,
+  AddedKeywordDefinition,
 } from "../../types"
 import {_, not, and, Name, Code} from "../../compile/codegen"
 import {alwaysValidSchema, Type} from "../../compile/util"
@@ -19,14 +20,17 @@ const error: KeywordErrorDefinition = {
   params: ({params}) => _`{unevaluatedProperty: ${params.unevaluatedProperty}}`,
 }
 
-const def: CodeKeywordDefinition = {
+const def: CodeKeywordDefinition & AddedKeywordDefinition = {
   keyword: "unevaluatedProperties",
-  type: "object",
+  type: ["object"],
   schemaType: ["boolean", "object"],
+  allowUndefined: true,
   trackErrors: true,
   error,
   code(cxt) {
-    const {gen, schema, data, errsCount, it} = cxt
+    const {gen, data, errsCount, it} = cxt
+   
+    const {schema = it.opts.defaultAdditionalProperties} = cxt;
     /* istanbul ignore if */
     if (!errsCount) throw new Error("ajv implementation error")
     const {allErrors, props} = it
@@ -43,6 +47,7 @@ const def: CodeKeywordDefinition = {
           : gen.if(unevaluatedStatic(props, key), () => unevaluatedPropCode(key))
       )
     }
+    
     it.props = true
     cxt.ok(_`${errsCount} === ${N.errors}`)
 

--- a/lib/vocabularies/unevaluated/unevaluatedProperties.ts
+++ b/lib/vocabularies/unevaluated/unevaluatedProperties.ts
@@ -28,9 +28,18 @@ const def: CodeKeywordDefinition & AddedKeywordDefinition = {
   trackErrors: true,
   error,
   code(cxt) {
-    const {gen, data, errsCount, it} = cxt
+    const {gen, data, errsCount, it} = cxt   
+    const {schema = it.opts.defaultAdditionalProperties} = cxt
+    // @ts-ignore 
+    const rootSchema = it.schemaEnv.root.schema?.allOf || [] as [any];
    
-    const {schema = it.opts.defaultAdditionalProperties} = cxt;
+   
+ 
+    if(rootSchema.find((item: any) => item?.['$ref'] === it.errSchemaPath)) {
+       // @ts-ignore 
+      return;
+    }
+
     /* istanbul ignore if */
     if (!errsCount) throw new Error("ajv implementation error")
     const {allErrors, props} = it

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ajv",
+  "name": "@redocly/ajv",
   "version": "8.6.0",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Relates issue https://github.com/Redocly/redocly-cli/issues/552
**What changes did you make?**
Support unevaluated properties by default in AJV. 

Unresolved problem - current solution proposed based on `errorPath` by which we can track `node` of JSON schema and omit putting `unevaluatedProperties` check inside `allOf` but there are problem with `ref`. In case of `ref` error path can be lost and wrong.

**Is there anything that requires more attention while reviewing?**
