### PR TITLE
fix: replace deprecated uri-js with uri-js-replace package

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -344,7 +344,7 @@ Include human-readable messages in errors. `true` by default. `false` can be pas
 
 ### uriResolver
 
-By default `uriResolver` is undefined and relies on the embedded uriResolver [uri-js](https://github.com/garycourt/uri-js). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [fast-uri](https://github.com/fastify/fast-uri).
+By default `uriResolver` is undefined and relies on the embedded uriResolver [uri-js-replace](https://github.com/andreinwald/uri-js-replace). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [fast-uri](https://github.com/fastify/fast-uri).
 
 ### code <Badge text="v7" />
 

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -14,7 +14,7 @@ import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
 import {schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
-import * as URI from "uri-js"
+import * as URI from "uri-js-replace"
 import {JSONType} from "./rules"
 
 export type SchemaRefs = {

--- a/lib/compile/jtd/types.ts
+++ b/lib/compile/jtd/types.ts
@@ -13,4 +13,4 @@ export const jtdForms = [
   "ref",
 ] as const
 
-export type JTDForm = typeof jtdForms[number]
+export type JTDForm = (typeof jtdForms)[number]

--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -1,6 +1,6 @@
 import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
-import type {URIComponents} from "uri-js"
+import type {URIComponents} from "uri-js-replace"
 import {eachItem} from "./util"
 import * as equal from "fast-deep-equal"
 import * as traverse from "json-schema-traverse"

--- a/lib/compile/rules.ts
+++ b/lib/compile/rules.ts
@@ -2,7 +2,7 @@ import type {AddedKeywordDefinition} from "../types"
 
 const _jsonTypes = ["string", "number", "integer", "boolean", "null", "object", "array"] as const
 
-export type JSONType = typeof _jsonTypes[number]
+export type JSONType = (typeof _jsonTypes)[number]
 
 const jsonTypes: Set<string> = new Set(_jsonTypes)
 

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -1,4 +1,4 @@
-import * as uri from "uri-js"
+import * as uri from "uri-js-replace"
 
 type URI = typeof uri & {code: string}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,4 @@
-import * as URI from "uri-js"
+import * as URI from "uri-js-replace"
 import type {CodeGen, Code, Name, ScopeValueSets, ValueScopeName} from "../compile/codegen"
 import type {SchemaEnv, SchemaCxt, SchemaObjCxt} from "../compile"
 import type {JSONType} from "../compile/rules"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.11.1",
+  "version": "8.11.0",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/chai": "^4.2.12",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^17.0.0",
+    "@types/node": "^22.5.4",
     "@types/require-from-string": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
@@ -106,7 +106,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.0.0",
     "tsify": "^5.0.2",
-    "typescript": "^4.2.0"
+    "typescript": "^5.5.4"
   },
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.11.0",
+  "version": "8.11.1",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",
@@ -63,7 +63,7 @@
     "fast-deep-equal": "^3.1.1",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2",
-    "uri-js": "^4.2.2"
+    "uri-js-replace": "^1.0.1"
   },
   "devDependencies": {
     "@ajv-validator/config": "^0.3.0",

--- a/spec/resolve.spec.ts
+++ b/spec/resolve.spec.ts
@@ -14,7 +14,7 @@ uriResolvers.forEach((resolver) => {
   if (resolver !== undefined) {
     describeTitle = "fast-uri resolver"
   } else {
-    describeTitle = "uri-js resolver"
+    describeTitle = "uri-js-replace resolver"
   }
   describe(describeTitle, () => {
     describe("resolve", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,11 @@
   "include": ["lib"],
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["ES2018", "DOM"],
+    "lib": ["ESNext"],
     "types": ["node"],
     "allowJs": true,
     "target": "ES2018",
+    "moduleResolution": "node",
     "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["lib"],
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["ES2018", "DOM"],
+    "lib": ["ESNext"],
     "types": ["node"],
     "allowJs": true,
     "target": "ES2018",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["lib"],
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["ESNext"],
+    "lib": ["ES2018", "DOM"],
     "types": ["node"],
     "allowJs": true,
     "target": "ES2018",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**


Replace `uri-js` with `uri-js-replace`.

`uri-js` using depricated transitive dependency of `punycode` package.
Causing warnings like this one:
```
(node:18708) [DEP0040] DeprecationWarning: The punycode module is deprecated. Please use a userland alternative instead.
(Use node --trace-deprecation ... to show where the warning was created)
```

**What changes did you make?**

**Is there anything that requires more attention while reviewing?**
