### PR TITLE
fix: enhance unevaluatedProperties handling for composite rules

### DIFF
--- a/lib/vocabularies/unevaluated/unevaluatedProperties.ts
+++ b/lib/vocabularies/unevaluated/unevaluatedProperties.ts
@@ -47,14 +47,16 @@ const def: CodeKeywordDefinition = {
             : gen.if(unevaluatedStatic(props, key), () => unevaluatedPropCode(key))
         )
 
-      if (isForced && it.errorPath.emptyStr()) {
+      if (isForced && it.errorPath.emptyStr() && !it.compositeRule) {
         // $refs are compiled into functions
         // We need to check in runtime if function was called from allOf.
         // We need to check only on the top level of the function:
         // it is ensured with `it.errorPath.emptyStr()` check
         gen.if(_`${N.isAllOfVariant} === 0`, staticCheck)
       } else {
-        staticCheck()
+        if (!it.compositeRule || cxt.schema !== undefined) {
+          staticCheck()
+        }
       }
     }
 

--- a/spec/default_unevaluated_properties.spec.ts
+++ b/spec/default_unevaluated_properties.spec.ts
@@ -365,16 +365,8 @@ describe("defaultUnevaluatedProperties=false option", function () {
   })
 
   function assertValid(schemas: SchemaObject[], data: unknown): void {
-    schemas.forEach(
-      (schema) => ajvs.forEach((ajv) => assert.strictEqual(ajv.validate(schema, data), true))
-      // ajvs.forEach((ajv) => {
-      //   console.log(JSON.stringify(schema, null, 2));
-      //   console.log(data);
-      //   const a = ajv.validate(schema, data);
-      //   console.log(a);
-      //   console.log(ajv.errors)
-      //   assert.strictEqual(a, true)
-      // })
+    schemas.forEach((schema) =>
+      ajvs.forEach((ajv) => assert.strictEqual(ajv.validate(schema, data), true))
     )
   }
 

--- a/spec/default_unevaluated_properties.spec.ts
+++ b/spec/default_unevaluated_properties.spec.ts
@@ -191,6 +191,75 @@ describe("defaultUnevaluatedProperties=false option", function () {
       assertInvalid(schemas, {foo: {baz: 1}})
       assertInvalid(schemas, {foo: {bar: "string", baz: 1}})
     })
+
+    it("should work correctly with anyOf", () => {
+      const schema1 = {
+        type: "object",
+        properties: {
+          address: {type: "string"},
+        },
+        anyOf: [
+          {
+            type: "object",
+            required: ["firstName", "lastName"],
+            properties: {
+              firstName: {type: "string"},
+              lastName: {type: "string"},
+            },
+          },
+          {
+            type: "object",
+            required: ["name"],
+            properties: {
+              name: {type: "string"},
+            },
+          },
+        ],
+      }
+
+      const schemas = [schema1]
+      assertInvalid(schemas, {})
+      assertValid(schemas, {address: "someWhere", firstName: "John", lastName: "Doe"})
+      assertValid(schemas, {address: "someWhere", name: "John Doe"})
+      assertInvalid(schemas, {address: "someWhere", firstName: "John"})
+      assertInvalid(schemas, {address: "someWhere", foo: 1})
+      assertValid(schemas, {firstName: "John", lastName: "Doe"})
+    })
+
+    it("should work correctly with oneOf", () => {
+      const schema1 = {
+        type: "object",
+        properties: {
+          address: {type: "string"},
+        },
+        oneOf: [
+          {
+            type: "object",
+            required: ["firstName", "lastName"],
+            properties: {
+              firstName: {type: "string"},
+              lastName: {type: "string"},
+            },
+          },
+          {
+            type: "object",
+            required: ["name"],
+            properties: {
+              name: {type: "string"},
+            },
+          },
+        ],
+      }
+
+      const schemas = [schema1]
+
+      assertInvalid(schemas, {})
+      assertValid(schemas, {address: "someWhere", firstName: "John", lastName: "Doe"})
+      assertValid(schemas, {address: "someWhere", name: "John Doe"})
+      assertInvalid(schemas, {firstName: "John", lastName: "Doe", name: "JD"})
+      assertInvalid(schemas, {address: "someWhere", foo: 1})
+      assertValid(schemas, {firstName: "John", lastName: "Doe"})
+    })
   })
 
   describe("validation with $refs", () => {
@@ -296,8 +365,16 @@ describe("defaultUnevaluatedProperties=false option", function () {
   })
 
   function assertValid(schemas: SchemaObject[], data: unknown): void {
-    schemas.forEach((schema) =>
-      ajvs.forEach((ajv) => assert.strictEqual(ajv.validate(schema, data), true))
+    schemas.forEach(
+      (schema) => ajvs.forEach((ajv) => assert.strictEqual(ajv.validate(schema, data), true))
+      // ajvs.forEach((ajv) => {
+      //   console.log(JSON.stringify(schema, null, 2));
+      //   console.log(data);
+      //   const a = ajv.validate(schema, data);
+      //   console.log(a);
+      //   console.log(ajv.errors)
+      //   assert.strictEqual(a, true)
+      // })
     )
   }
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

fix for: redocly cli [#1737](https://github.com/Redocly/redocly-cli/issues/1737)

**What changes did you make?**

Changes in unevaluatedProperties.ts to skip the forced static check in anyOf/oneOf. This removes false unevaluatedProperties errors and allows schema to pass validly with the current example:

```js
const schema = {
  type: "object",
  properties: {
    address: {type: "string"},
  },
  anyOf: [
    {
      type: "object",
      required: ["firstName", "lastName"],
      properties: {
        firstName: {type: "string"},
        lastName: {type: "string"},
      },
    },
    {
      type: "object",
      required: ["name"],
      properties: {
        name: {type: "string"},
      },
    },
  ],
};

const data = {
  address: "someWhere",
  firstName: "John",
  lastName: "Doe",
};

ajv.validate(schema, data); // should be true
```

**Is there anything that requires more attention while reviewing?**
