### PR TITLE
feat: add handling for draft-04 style for boolean in exclusiveMinimum and exclusiveMaximum

### DIFF
--- a/lib/vocabularies/validation/index.ts
+++ b/lib/vocabularies/validation/index.ts
@@ -1,5 +1,6 @@
 import type {ErrorObject, Vocabulary} from "../../types"
 import limitNumber, {LimitNumberError} from "./limitNumber"
+import limitNumberExclusive, {ExclusiveLimitNumberError} from "./limitNumberExclusive"
 import multipleOf, {MultipleOfError} from "./multipleOf"
 import limitLength from "./limitLength"
 import pattern, {PatternError} from "./pattern"
@@ -13,6 +14,7 @@ import enumKeyword, {EnumError} from "./enum"
 const validation: Vocabulary = [
   // number
   limitNumber,
+  limitNumberExclusive,
   multipleOf,
   // string
   limitLength,
@@ -41,6 +43,7 @@ type LimitError = ErrorObject<
 export type ValidationKeywordError =
   | LimitError
   | LimitNumberError
+  | ExclusiveLimitNumberError
   | MultipleOfError
   | PatternError
   | RequiredError

--- a/lib/vocabularies/validation/limitNumberExclusive.ts
+++ b/lib/vocabularies/validation/limitNumberExclusive.ts
@@ -1,0 +1,54 @@
+import type {KeywordCxt} from "../../compile/validate"
+import type {CodeKeywordDefinition, ErrorObject, KeywordErrorDefinition} from "../../types"
+import {_, str, operators} from "../../compile/codegen"
+import type {LimitKwd, ExclusiveLimitKwd} from "./limitNumber"
+
+const ops = operators
+
+const KWDs: {[K in ExclusiveLimitKwd]: LimitKwd} = {
+  exclusiveMaximum: "maximum",
+  exclusiveMinimum: "minimum",
+}
+
+export type ExclusiveLimitNumberError = ErrorObject<
+  ExclusiveLimitKwd,
+  {limit: number; comparison: "<" | ">"},
+  number | {$data: string}
+>
+
+const error: KeywordErrorDefinition = {
+  message: (cxt) => {
+    const op = cxt.keyword === "exclusiveMaximum" ? "<" : ">"
+    return str`must be ${op} ${cxt.schemaCode}`
+  },
+  params: (cxt) => {
+    const comparison = cxt.keyword === "exclusiveMaximum" ? "<" : ">"
+    return _`{comparison: ${comparison}, limit: ${cxt.schemaCode}}`
+  },
+}
+
+const def: CodeKeywordDefinition = {
+  keyword: Object.keys(KWDs),
+  type: "number",
+  schemaType: ["boolean", "number"],
+  $data: true,
+  error,
+  code(cxt: KeywordCxt) {
+    const {data, schemaCode, keyword, schema, parentSchema} = cxt
+
+    if (typeof schema === "boolean") {
+      // Draft-04 style: boolean exclusiveMaximum/exclusiveMinimum
+      const limitKwd = KWDs[keyword as ExclusiveLimitKwd]
+      if (parentSchema[limitKwd] === undefined) {
+        throw new Error(`${keyword} can only be used with ${limitKwd}`)
+      }
+      return
+    }
+
+    // Draft-06+ style: numeric exclusiveMaximum/exclusiveMinimum
+    const failOp = keyword === "exclusiveMaximum" ? ops.GTE : ops.LTE
+    cxt.fail$data(_`${data} ${failOp} ${schemaCode} || isNaN(${data})`)
+  },
+}
+
+export default def

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@redocly/ajv",
+  "name": "ajv",
   "version": "8.11.3",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ajv",
+  "name": "@redocly/ajv",
   "version": "8.11.3",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",

--- a/spec/extras/$data/maximum.json
+++ b/spec/extras/$data/maximum.json
@@ -72,14 +72,6 @@
     },
     "tests": [
       {
-        "description": "exclusiveMaximum boolean is supported",
-        "data": {
-          "number": 4,
-          "exclusiveMaximum": true
-        },
-        "valid": true
-      },
-      {
         "description": "below the maximum is valid when exclusiveMaximum is strictly larger",
         "data": {
           "number": 4,

--- a/spec/extras/$data/maximum.json
+++ b/spec/extras/$data/maximum.json
@@ -72,12 +72,12 @@
     },
     "tests": [
       {
-        "description": "exclusiveMaximum boolean no longer supported",
+        "description": "exclusiveMaximum boolean is supported",
         "data": {
           "number": 4,
           "exclusiveMaximum": true
         },
-        "valid": false
+        "valid": true
       },
       {
         "description": "below the maximum is valid when exclusiveMaximum is strictly larger",
@@ -156,13 +156,13 @@
     },
     "tests": [
       {
-        "description": "exclusiveMaximum boolean no longer supported",
+        "description": "exclusiveMaximum boolean is supported",
         "data": {
           "larger": 3,
-          "smallerOrEqual": 2,
+          "smallerOrEqual": 0,
           "exclusiveMaximum": true
         },
-        "valid": false
+        "valid": true
       },
       {
         "description": "below the maximum is valid when exclusiveMaximum is strictly larger",

--- a/spec/extras/$data/maximum.json
+++ b/spec/extras/$data/maximum.json
@@ -156,15 +156,6 @@
     },
     "tests": [
       {
-        "description": "exclusiveMaximum boolean is supported",
-        "data": {
-          "larger": 3,
-          "smallerOrEqual": 0,
-          "exclusiveMaximum": true
-        },
-        "valid": true
-      },
-      {
         "description": "below the maximum is valid when exclusiveMaximum is strictly larger",
         "data": {
           "larger": 3,

--- a/spec/extras/$data/minimum.json
+++ b/spec/extras/$data/minimum.json
@@ -65,14 +65,6 @@
     },
     "tests": [
       {
-        "description": "exclusiveMinimum boolean is supported",
-        "data": {
-          "number": 4,
-          "exclusiveMinimum": true
-        },
-        "valid": true
-      },
-      {
         "description": "above the minimum is valid when exclusiveMinimum is strictly smaller",
         "data": {
           "number": 4,

--- a/spec/extras/$data/minimum.json
+++ b/spec/extras/$data/minimum.json
@@ -65,12 +65,12 @@
     },
     "tests": [
       {
-        "description": "exclusiveMinimum boolean no longer supported",
+        "description": "exclusiveMinimum boolean is supported",
         "data": {
           "number": 4,
           "exclusiveMinimum": true
         },
-        "valid": false
+        "valid": true
       },
       {
         "description": "above the minimum is valid when exclusiveMinimum is strictly smaller",
@@ -149,13 +149,13 @@
     },
     "tests": [
       {
-        "description": "exclusiveMinimum boolean no longer supported",
+        "description": "exclusiveMinimum boolean is supported",
         "data": {
           "smaller": 3,
           "largerOrEqual": 4,
           "exclusiveMinimum": true
         },
-        "valid": false
+        "valid": true
       },
       {
         "description": "above the minimum is valid when exclusiveMinimum is strictly smaller",

--- a/spec/extras/$data/minimum.json
+++ b/spec/extras/$data/minimum.json
@@ -65,6 +65,14 @@
     },
     "tests": [
       {
+        "description": "exclusiveMinimum boolean no longer supported",
+        "data": {
+          "number": 4,
+          "exclusiveMinimum": true
+        },
+        "valid": false
+      },
+      {
         "description": "above the minimum is valid when exclusiveMinimum is strictly smaller",
         "data": {
           "number": 4,
@@ -140,15 +148,6 @@
       }
     },
     "tests": [
-      {
-        "description": "exclusiveMinimum boolean is supported",
-        "data": {
-          "smaller": 3,
-          "largerOrEqual": 4,
-          "exclusiveMinimum": true
-        },
-        "valid": true
-      },
       {
         "description": "above the minimum is valid when exclusiveMinimum is strictly smaller",
         "data": {

--- a/spec/extras/$data/minimum.json
+++ b/spec/extras/$data/minimum.json
@@ -65,14 +65,6 @@
     },
     "tests": [
       {
-        "description": "exclusiveMinimum boolean no longer supported",
-        "data": {
-          "number": 4,
-          "exclusiveMinimum": true
-        },
-        "valid": false
-      },
-      {
         "description": "above the minimum is valid when exclusiveMinimum is strictly smaller",
         "data": {
           "number": 4,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Resolves [#1610](https://github.com/Redocly/redocly-cli/issues/1610)

**What changes did you make?**
- Changed `limitNumbers.ts` functionality to trigger only for `minimum` and `maximum` keywords. However, `kwdOp`  function will check if boolean `exclusiveMinimum`/`exclusiveMaximum` exists in parent and return proper validation operation.
- Added `limitNumberExclusive.ts` file to trigger only when `exclusiveMinimum`/`exclusiveMaximum` provided.
- Removed irrelevant tests due to draft-04 doesn't support resolving $data in runtime.

**Is there anything that requires more attention while reviewing?**
