### PR TITLE
chore: remove NPM_TOKEN and bundle publishing step in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,9 @@ jobs:
       - name: Publish to npm
         if: ${{ !github.event.release.prerelease }}
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Commit bundles to ajv-dist
-        run: ./scripts/publish-bundles
-        env:
-          GH_TOKEN_PUBLIC: ${{ secrets.GH_TOKEN_PUBLIC }}
-          GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
+      # - name: Commit bundles to ajv-dist
+      #   run: ./scripts/publish-bundles
+      #   env:
+      #     GH_TOKEN_PUBLIC: ${{ secrets.GH_TOKEN_PUBLIC }}
+      #     GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
+      #     GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}


### PR DESCRIPTION
What issue does this pull request resolve?

The `publish` GitHub Actions workflow is currently failing in CI because it depends on the `NPM_TOKEN` secret and tries to commit bundles to the `ajv-dist` repository. In our setup we use npm Trusted Publisher for authentication, which does not require an `NPM_TOKEN`.

What changes did you make?

- Removed usage of the `NPM_TOKEN` secret in the `Publish to npm` step, since npm Trusted Publisher is used instead and does not require a token.
- Removed the step that commits bundles to the `ajv-dist` repository from the workflow.
- Left the previous `ajv-dist` step commented out for future reference, in case we decide to reintroduce bundle publishing later.

Is there anything that requires more attention while reviewing?

\-