### PR TITLE
chore: update Node.js version to 20 and install latest npm in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+      - run: npm install -g npm@latest
       - run: npm install
       - run: git submodule update --init
       - run: npm run test-ci


### PR DESCRIPTION
What issue does this pull request resolve?

The `publish` GitHub Actions workflow may run with an npm version that is too old for npm Trusted Publishing. To reliably use trusted publishing (with OIDC), we should ensure that the workflow runs on an npm version **11.5.1 or later**, instead of relying on whatever version is preinstalled on the runner.

What changes did you make?

- Updated the `actions/setup-node` step in `.github/workflows/publish.yml` to use **Node.js 20**.
- Added a step to install **npm@^11.5.1** before running any npm commands, to guarantee a version that fully supports trusted publishing.
- Left the rest of the workflow unchanged.

Is there anything that requires more attention while reviewing?

\-