### PR TITLE
chore: update repository information

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
       "text-summary"
     ]
   },
-  "repository": "ajv-validator/ajv",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Redocly/ajv.git"
+  },
   "keywords": [
     "JSON",
     "schema",
@@ -57,8 +60,6 @@
   ],
   "author": "Evgeny Poberezkin",
   "license": "MIT",
-  "bugs": "https://github.com/ajv-validator/ajv/issues",
-  "homepage": "https://ajv.js.org",
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

It fixes the trusted publishing failure for `@redocly/ajv` on `npm`, where the publish step returns `422 Unprocessable Entity due to a provenance validation error`. The error is caused by `package.json` having `repository.url` set to `git+https://github.com/ajv-validator/ajv.git`, while npm expects it to match `https://github.com/Redocly/ajv` from the provenance metadata ([see the GitHub Actions run](https://github.com/Redocly/ajv/actions/runs/19145344658/job/54721369529)).

**What changes did you make?**

Updated the repository.url in package.json

**Is there anything that requires more attention while reviewing?**
