### PR TITLE
feat: add draft4 support

### DIFF
--- a/lib/draft4.ts
+++ b/lib/draft4.ts
@@ -1,0 +1,79 @@
+import type {AnySchemaObject, Options} from "./core"
+import AjvCore from "./core"
+import draft4Vocabularies from "./vocabularies/draft4"
+import discriminator from "./vocabularies/discriminator"
+import * as draft4MetaSchema from "./refs/json-schema-draft-04.json"
+
+const META_SUPPORT_DATA = ["/properties"]
+
+const META_SCHEMA_ID = "http://json-schema.org/draft-04/schema"
+
+class Ajv extends AjvCore {
+  constructor(opts: Options = {}) {
+    super({
+      ...opts,
+      schemaId: "id",
+      dynamicRef: true,
+      unevaluated: true,
+    })
+  }
+
+  _addVocabularies(): void {
+    super._addVocabularies()
+    draft4Vocabularies.forEach((v) => this.addVocabulary(v))
+    if (this.opts.discriminator) this.addKeyword(discriminator)
+  }
+
+  _addDefaultMetaSchema(): void {
+    super._addDefaultMetaSchema()
+    if (!this.opts.meta) return
+    const metaSchema = this.opts.$data
+      ? this.$dataMetaSchema(draft4MetaSchema, META_SUPPORT_DATA)
+      : draft4MetaSchema
+    this.addMetaSchema(metaSchema, META_SCHEMA_ID, false)
+    this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID
+  }
+
+  defaultMeta(): string | AnySchemaObject | undefined {
+    return (this.opts.defaultMeta =
+      super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : undefined))
+  }
+}
+
+module.exports = exports = Ajv
+Object.defineProperty(exports, "__esModule", {value: true})
+
+export default Ajv
+
+export {
+  Format,
+  FormatDefinition,
+  AsyncFormatDefinition,
+  KeywordDefinition,
+  KeywordErrorDefinition,
+  CodeKeywordDefinition,
+  MacroKeywordDefinition,
+  FuncKeywordDefinition,
+  Vocabulary,
+  Schema,
+  SchemaObject,
+  AnySchemaObject,
+  AsyncSchema,
+  AnySchema,
+  ValidateFunction,
+  AsyncValidateFunction,
+  SchemaValidateFunction,
+  ErrorObject,
+  ErrorNoParams,
+  Context,
+} from "./types"
+
+export {Plugin, Options, CodeOptions, InstanceOptions, Logger, ErrorsTextOptions} from "./core"
+export {SchemaCxt, SchemaObjCxt} from "./compile"
+export {KeywordCxt} from "./compile/validate"
+export {DefinedError} from "./vocabularies/errors"
+export {JSONType} from "./compile/rules"
+export {JSONSchemaType} from "./types/json-schema"
+export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
+export {default as ValidationError} from "./runtime/validation_error"
+export {default as MissingRefError} from "./compile/ref_error"

--- a/lib/refs/json-schema-draft-04.json
+++ b/lib/refs/json-schema-draft-04.json
@@ -1,0 +1,138 @@
+{
+  "id": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Core schema meta-schema",
+  "definitions": {
+    "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#"}
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "positiveIntegerDefault0": {
+      "allOf": [{"$ref": "#/definitions/positiveInteger"}, {"default": 0}]
+    },
+    "simpleTypes": {
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": {},
+    "multipleOf": {
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "boolean",
+      "default": false
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxLength": {"$ref": "#/definitions/positiveInteger"},
+    "minLength": {"$ref": "#/definitions/positiveIntegerDefault0"},
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "additionalItems": {
+      "anyOf": [{"type": "boolean"}, {"$ref": "#"}],
+      "default": {}
+    },
+    "items": {
+      "anyOf": [{"$ref": "#"}, {"$ref": "#/definitions/schemaArray"}],
+      "default": {}
+    },
+    "maxItems": {"$ref": "#/definitions/positiveInteger"},
+    "minItems": {"$ref": "#/definitions/positiveIntegerDefault0"},
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxProperties": {"$ref": "#/definitions/positiveInteger"},
+    "minProperties": {"$ref": "#/definitions/positiveIntegerDefault0"},
+    "required": {"$ref": "#/definitions/stringArray"},
+    "additionalProperties": {
+      "anyOf": [{"type": "boolean"}, {"$ref": "#"}],
+      "default": {}
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#"},
+      "default": {}
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#"},
+      "default": {}
+    },
+    "patternProperties": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#"},
+      "default": {}
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [{"$ref": "#"}, {"$ref": "#/definitions/stringArray"}]
+      }
+    },
+    "enum": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type": {
+      "anyOf": [
+        {"$ref": "#/definitions/simpleTypes"},
+        {
+          "type": "array",
+          "items": {"$ref": "#/definitions/simpleTypes"},
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "allOf": {"$ref": "#/definitions/schemaArray"},
+    "anyOf": {"$ref": "#/definitions/schemaArray"},
+    "oneOf": {"$ref": "#/definitions/schemaArray"},
+    "not": {"$ref": "#"}
+  },
+  "dependencies": {
+    "exclusiveMaximum": ["maximum"],
+    "exclusiveMinimum": ["minimum"]
+  },
+  "default": {}
+}

--- a/lib/vocabularies/draft4.ts
+++ b/lib/vocabularies/draft4.ts
@@ -1,0 +1,32 @@
+import {Vocabulary} from "../types"
+import refKeyword from "./core/ref"
+import getApplicatorVocabulary from "./applicator"
+import unevaluatedVocabulary from "./unevaluated"
+import formatVocabulary from "./format"
+import validationVocabulary from "./validation"
+import limitNumber from "./validation/draft04/limitNumber"
+import limitNumberExclusive from "./validation/draft04/limitNumberExclusive"
+
+const metadataVocabulary: Vocabulary = ["title", "description", "default"]
+
+const coreVocabulary: Vocabulary = [
+  "$schema",
+  "$id",
+  "$defs",
+  {keyword: "$comment"},
+  "definitions",
+  refKeyword,
+]
+
+const validation: Vocabulary = [...validationVocabulary.slice(1), limitNumber, limitNumberExclusive]
+
+const draft4Vocabularies: Vocabulary[] = [
+  coreVocabulary,
+  validation,
+  getApplicatorVocabulary(),
+  formatVocabulary,
+  metadataVocabulary,
+  unevaluatedVocabulary,
+]
+
+export default draft4Vocabularies

--- a/lib/vocabularies/draft4.ts
+++ b/lib/vocabularies/draft4.ts
@@ -11,7 +11,7 @@ const metadataVocabulary: Vocabulary = ["title", "description", "default"]
 
 const coreVocabulary: Vocabulary = [
   "$schema",
-  "$id",
+  "id",
   "$defs",
   {keyword: "$comment"},
   "definitions",

--- a/lib/vocabularies/validation/draft04/limitNumber.ts
+++ b/lib/vocabularies/validation/draft04/limitNumber.ts
@@ -1,0 +1,75 @@
+import type {
+  CodeKeywordDefinition,
+  ErrorObject,
+  KeywordErrorDefinition,
+  KeywordErrorCxt,
+} from "../../../types"
+import type {KeywordCxt} from "../../../compile/validate"
+import {_, str, operators, Code} from "../../../compile/codegen"
+
+const ops = operators
+
+export type LimitKwd = "maximum" | "minimum"
+
+export type ExclusiveLimitKwd = "exclusiveMaximum" | "exclusiveMinimum"
+
+type Comparison = "<=" | ">=" | "<" | ">"
+
+interface KwdOp {
+  okStr: Comparison
+  ok: Code
+  fail: Code
+}
+
+interface KwdDef {
+  exclusive: ExclusiveLimitKwd
+  ops: [KwdOp, KwdOp]
+}
+
+const KWDs: {[K in LimitKwd]: KwdDef} = {
+  maximum: {
+    exclusive: "exclusiveMaximum",
+    ops: [
+      {okStr: "<=", ok: ops.LTE, fail: ops.GT},
+      {okStr: "<", ok: ops.LT, fail: ops.GTE},
+    ],
+  },
+  minimum: {
+    exclusive: "exclusiveMinimum",
+    ops: [
+      {okStr: ">=", ok: ops.GTE, fail: ops.LT},
+      {okStr: ">", ok: ops.GT, fail: ops.LTE},
+    ],
+  },
+}
+
+export type LimitNumberError = ErrorObject<
+  LimitKwd,
+  {limit: number; comparison: Comparison},
+  number | {$data: string}
+>
+
+const error: KeywordErrorDefinition = {
+  message: (cxt) => str`must be ${kwdOp(cxt).okStr} ${cxt.schemaCode}`,
+  params: (cxt) => _`{comparison: ${kwdOp(cxt).okStr}, limit: ${cxt.schemaCode}}`,
+}
+
+const def: CodeKeywordDefinition = {
+  keyword: Object.keys(KWDs),
+  type: "number",
+  schemaType: "number",
+  $data: true,
+  error,
+  code(cxt: KeywordCxt) {
+    const {data, schemaCode} = cxt
+    cxt.fail$data(_`${data} ${kwdOp(cxt).fail} ${schemaCode} || isNaN(${data})`)
+  },
+}
+
+function kwdOp(cxt: KeywordErrorCxt): KwdOp {
+  const keyword = cxt.keyword as LimitKwd
+  const opsIdx = cxt.parentSchema?.[KWDs[keyword].exclusive] ? 1 : 0
+  return KWDs[keyword].ops[opsIdx]
+}
+
+export default def

--- a/lib/vocabularies/validation/draft04/limitNumberExclusive.ts
+++ b/lib/vocabularies/validation/draft04/limitNumberExclusive.ts
@@ -1,0 +1,26 @@
+import type {
+  CodeKeywordDefinition,
+  // ErrorObject,
+  // KeywordErrorDefinition,
+} from "../../../types"
+import type {KeywordCxt} from "../../../compile/validate"
+import {LimitKwd, ExclusiveLimitKwd} from "./limitNumber"
+
+const KWDs: {[K in ExclusiveLimitKwd]: LimitKwd} = {
+  exclusiveMaximum: "maximum",
+  exclusiveMinimum: "minimum",
+}
+
+const def: CodeKeywordDefinition = {
+  keyword: Object.keys(KWDs),
+  type: "number",
+  schemaType: "boolean",
+  code({keyword, parentSchema}: KeywordCxt) {
+    const limitKwd = KWDs[keyword as ExclusiveLimitKwd]
+    if (parentSchema[limitKwd] === undefined) {
+      throw new Error(`${keyword} can only be used with ${limitKwd}`)
+    }
+  },
+}
+
+export default def

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.17.3",
+  "version": "8.17.4",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.17.4",
+  "version": "8.17.3",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

This PR addresses draft-04 compatibility gaps impacting OpenAPI example validation for OAS 3.0 and earlier (including 2.0). It is related to the CLI issue: https://github.com/Redocly/redocly-cli/issues/1610

**What changes did you make?**

* Added support for JSON Schema draft-04 to improve validation of OpenAPI `example(s)` in specs that rely on draft-04-era semantics (OAS 3.0 and below).
* The implementation is based on the official Ajv draft-04 package approach and code structure: https://github.com/ajv-validator/ajv-draft-04/tree/master
* Wired draft-04 meta-schema / vocabulary handling so draft-04 schemas can be compiled and validated correctly in this fork.

**Is there anything that requires more attention while reviewing?**

* **Meta-schema switching:** draft-04 and later drafts (e.g., 2019-09 / 2020-12) use different vocabularies/keywords, so you **cannot safely “switch” the meta-schema within a single Ajv instance** and expect consistent behavior. Mixing drafts in one instance can lead to keyword/vocabulary conflicts and incorrect validation.
  Recommended approach is to keep draft-04 support isolated

Related prs: 
- ajv: https://github.com/Redocly/ajv/pull/30
- cli: TBD
