### PR TITLE
chore: remove named export override

### DIFF
--- a/lib/2020.ts
+++ b/lib/2020.ts
@@ -37,7 +37,6 @@ export class Ajv2020 extends AjvCore {
   }
 }
 
-module.exports = exports = Ajv2020
 module.exports.Ajv2020 = Ajv2020
 Object.defineProperty(exports, "__esModule", {value: true})
 

--- a/lib/draft4.ts
+++ b/lib/draft4.ts
@@ -40,7 +40,6 @@ export class Ajv extends AjvCore {
   }
 }
 
-module.exports = exports = Ajv
 Object.defineProperty(exports, "__esModule", {value: true})
 
 export default Ajv

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redocly/ajv",
-  "version": "8.18.1",
+  "version": "8.18.2",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/spec/ajv2020.ts
+++ b/spec/ajv2020.ts
@@ -1,6 +1,6 @@
 import type Ajv2020 from "../dist/2019"
 const AjvClass: typeof Ajv2020 =
-  typeof window == "object" ? (window as any).ajv2020 : require("" + "../dist/2020")
+  typeof window == "object" ? (window as any).ajv2020 : require("" + "../dist/2020").Ajv2020
 
 export default AjvClass
 module.exports = AjvClass


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
I didn't have named import in runtime due to this override, what caused failing tests.

**What changes did you make?**
Removed `module.exports = exports = Ajv2020`

**Is there anything that requires more attention while reviewing?**